### PR TITLE
Add support for alternate S3 services

### DIFF
--- a/aws.cfc
+++ b/aws.cfc
@@ -10,6 +10,7 @@ component {
         'personalizeEvents',
         'personalizeRuntime',
         's3',
+        's3_other',
         'sns',
         'sqs',
         'rekognition',
@@ -27,6 +28,7 @@ component {
         personalizeEvents: { apiVersion: '2018-03-22' },
         rekognition: { apiVersion: '2016-06-27' },
         s3: { },
+        s3_other: { },
         sns: { apiVersion: '2010-03-31' },
         sqs: { apiVersion: '2012-11-05' },
         translate: { apiVersion: '20170701', defaultSourceLanguageCode: 'es', defaultTargetLanguageCode: 'en' }

--- a/com/api.cfc
+++ b/com/api.cfc
@@ -51,8 +51,7 @@ component accessors="true" {
         struct headers = { },
         any body = '',
         struct awsCredentials = { },
-        boolean encodeurl = true,
-        boolean useSSL = true
+        boolean encodeurl = true
     ) {
         if ( awsCredentials.isEmpty() ) {
             awsCredentials = credentials.getCredentials();
@@ -78,7 +77,6 @@ component accessors="true" {
         httpArgs[ 'path' ] = host & encodedPath;
         httpArgs[ 'headers' ] = signedRequestHeaders;
         httpArgs[ 'queryParams' ] = queryParams;
-        httpArgs[ 'useSSL' ] = useSSL;
         if ( !isNull( arguments.body ) ) httpArgs[ 'body' ] = body;
         // writeDump( httpArgs );
 
@@ -91,7 +89,6 @@ component accessors="true" {
         apiResponse[ 'responseHeaders' ] = rawResponse.responseheader;
         apiResponse[ 'statusCode' ] = listFirst( rawResponse.statuscode, ' ' );
         apiResponse[ 'rawData' ] = rawResponse.filecontent;
-        apiResponse[ 'host' ] = arguments.host;
 
         if ( apiResponse.statusCode != 200 && isXML( apiResponse.rawData ) ) {
             apiResponse[ 'error' ] = utils.parseXmlDocument( apiResponse.rawData );

--- a/com/api.cfc
+++ b/com/api.cfc
@@ -51,7 +51,8 @@ component accessors="true" {
         struct headers = { },
         any body = '',
         struct awsCredentials = { },
-        boolean encodeurl = true
+        boolean encodeurl = true,
+        boolean useSSL = true
     ) {
         if ( awsCredentials.isEmpty() ) {
             awsCredentials = credentials.getCredentials();
@@ -77,6 +78,7 @@ component accessors="true" {
         httpArgs[ 'path' ] = host & encodedPath;
         httpArgs[ 'headers' ] = signedRequestHeaders;
         httpArgs[ 'queryParams' ] = queryParams;
+        httpArgs[ 'useSSL' ] = useSSL;
         if ( !isNull( arguments.body ) ) httpArgs[ 'body' ] = body;
         // writeDump( httpArgs );
 
@@ -89,6 +91,7 @@ component accessors="true" {
         apiResponse[ 'responseHeaders' ] = rawResponse.responseheader;
         apiResponse[ 'statusCode' ] = listFirst( rawResponse.statuscode, ' ' );
         apiResponse[ 'rawData' ] = rawResponse.filecontent;
+        apiResponse[ 'host' ] = arguments.host;
 
         if ( apiResponse.statusCode != 200 && isXML( apiResponse.rawData ) ) {
             apiResponse[ 'error' ] = utils.parseXmlDocument( apiResponse.rawData );

--- a/com/utils.cfc
+++ b/com/utils.cfc
@@ -72,7 +72,7 @@ component {
     public array function parseHeaders(
         required struct headers
     ) {
-        var sortedKeyArray = headers.keyArray();
+        var sortedKeyArray = arguments.headers.keyArray();
         sortedKeyArray.sort( 'textnocase' );
         var processedHeaders = sortedKeyArray.map( function( key ) {
             return { name: key.lcase(), value: trim( headers[ key ] ) };

--- a/services/s3.cfc
+++ b/services/s3.cfc
@@ -279,7 +279,6 @@ component {
     public any function deleteBucket(
         required string Bucket
     ) {
-		var requestSettings = api.resolveRequestSettings( argumentCollection = arguments );
         return apiCall( requestSettings, 'DELETE', '/' & Bucket );
     }
 

--- a/services/s3.cfc
+++ b/services/s3.cfc
@@ -279,6 +279,7 @@ component {
     public any function deleteBucket(
         required string Bucket
     ) {
+		var requestSettings = api.resolveRequestSettings( argumentCollection = arguments );
         return apiCall( requestSettings, 'DELETE', '/' & Bucket );
     }
 

--- a/services/s3.cfc
+++ b/services/s3.cfc
@@ -279,6 +279,7 @@ component {
     public any function deleteBucket(
         required string Bucket
     ) {
+        var requestSettings = api.resolveRequestSettings( argumentCollection = arguments );
         return apiCall( requestSettings, 'DELETE', '/' & Bucket );
     }
 

--- a/services/s3_other.cfc
+++ b/services/s3_other.cfc
@@ -1,0 +1,56 @@
+component extends="s3"{
+
+    variables.service = 's3_other';
+
+    public any function init(
+        required any api,
+        required struct settings
+    ) {
+        variables.api = arguments.api;
+        variables.utils = variables.api.getUtils();
+        variables.emptyStringHash = hash( '', 'SHA-256' ).lcase();
+        variables.host = arguments.settings.host;
+        variables.useSSL = arguments.settings.useSSL;
+        return this;
+    }
+
+    // private
+
+    private string function getHost(
+        required string region
+    ) {
+        return variables.host;
+    }
+
+    private any function apiCall(
+        required struct requestSettings,
+        string httpMethod = 'GET',
+        string path = '/',
+        struct queryParams = { },
+        struct headers = { },
+        any payload = ''
+    ) {
+        var host = getHost( requestSettings.region );
+
+        if ( !isSimpleValue( payload ) || len( payload ) ) {
+            headers[ 'X-Amz-Content-Sha256' ] = hash( payload, 'SHA-256' ).lcase();
+        } else {
+            headers[ 'X-Amz-Content-Sha256' ] = variables.emptyStringHash;
+        }
+
+        return api.call(
+            "s3",
+            host,
+            requestSettings.region,
+            httpMethod,
+            path,
+            queryParams,
+            headers,
+            payload,
+            requestSettings.awsCredentials,
+            true,
+            variables.useSSL
+        );
+    }
+
+}


### PR DESCRIPTION
allow overriding the hardwired support amazon s3 hostnames

so that local or other s3 servers like mimio (https://min.io/ ) etc can be used for local testing etc

```
mimio = new aws(
	awsKey = '***',
	awsSecretKey = '***',
	defaultRegion = 'us-east-1',
	constructorArgs = {
		s3_other: {
			host = 'localhost:9000',
			useSSL = false
		}
	}
);
```