### PR TITLE
cf11 ; compatibility fix

### DIFF
--- a/services/sqs.cfc
+++ b/services/sqs.cfc
@@ -197,7 +197,7 @@ component {
             'Attribute.3.Value': receiveMessageWaitTimeSeconds,
             'Attribute.4.Name': 'VisibilityTimeout',
             'Attribute.4.Value': visibilityTimeout
-        }
+        };
         // Only append fifo attributes for fifo queues
         if ( fifoQueue ) {
             structAppend(


### PR DESCRIPTION
Payload variable in createQueue function was not terminated with a semicolon, causing an error with CF11.