### PR TITLE
Update sqs.cfc

### DIFF
--- a/services/sqs.cfc
+++ b/services/sqs.cfc
@@ -130,6 +130,16 @@ component {
         );
         if ( apiResponse.statusCode == 200 ) {
             apiResponse[ 'data' ] = utils.parseXmlDocument( apiResponse.rawData );
+            apiResponse[ 'messages' ] = [];
+            if(structKeyExists(apiResponse.data,'ReceiveMessageResult')){
+                if(isArray(apiResponse.data.ReceiveMessageResult)){
+                    for (var message in apiResponse.data.ReceiveMessageResult) {
+                        arrayAppend(apiResponse[ 'messages' ], message );
+                    }
+                }elseif(isStruct(apiResponse.data.ReceiveMessageResult)){
+                    arrayAppend(apiResponse[ 'messages' ], apiResponse.data.ReceiveMessageResult.message );
+                }   
+            }
         }
         return apiResponse;
     }


### PR DESCRIPTION
return messages in an array, backwards compatible and always exists on a 200, simple check they array length, no longer need to check for single or > 1 or is a struct or is an array.