### PR TITLE
modifed deleteObject() and deleteMultipleObjects() to support deletio…

### DIFF
--- a/services/s3.cfc
+++ b/services/s3.cfc
@@ -594,17 +594,17 @@ component {
     * http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectDELETE.html
     * @Bucket the name of the bucket containing the object
     * @ObjectKey the object key
+    * @VersionId the specific version of an object to delete (if versioning is enabled)
     */
     public any function deleteObject(
         required string Bucket,
-        required string ObjectKey
+        required string ObjectKey,
+        string VersionId = ''
     ) {
         var requestSettings = api.resolveRequestSettings( argumentCollection = arguments );
-
-        return findNoCase("?versionid=",arguments.ObjectKey)
-            ? deleteMultipleObjects(Bucket=arguments.Bucket,ObjectKeys=[arguments.ObjectKey])
-            : apiCall( requestSettings, 'DELETE', '/' & bucket & '/' & objectKey );
-
+        var queryParams = { };
+        if ( len( arguments.VersionId ) ) queryParams[ 'versionId' ] = arguments.VersionId;
+        return apiCall( requestSettings, 'DELETE', '/' & objectKey, queryParams );
     }
 
     /**


### PR DESCRIPTION
The deleteObject() and deleteMultipleObjects() methods did not support deleting specific versions of objects. 

Adding support for object versions to deleteMultipleObjects() was relatively easy. Amazon supports a <versionid> for the <object> node when doing batch deletion. The ObjectKeys param can now be a single string with a key or a struct with a key and the version. The proper versionid node will be inserted if it exists.

The singular deleteObject() was more problematic. According to the AWS docs appending a ?versionid=[versionid] to the object key should identify the file version to delete in the DELETE action. But, I was unable to get it to work. After confirming the key and url params were correct on the request it was simply being ignored by AWS. The latest version of the object waas always deleted. So to work around the issue, a ?versionid=[versionid] param can be added to the ObjectKey when calling deleteObject() and it will be parsed and passed to the deleteMultipleObject() method. Otherwise, a delete action will delete the latest version of the object.