### PR TITLE
Adding an optional timeout to the s3 putObject function

### DIFF
--- a/com/api.cfc
+++ b/com/api.cfc
@@ -58,7 +58,8 @@ component accessors="true" {
         any body = '',
         struct awsCredentials = { },
         boolean encodeurl = true,
-        boolean useSSL = true
+        boolean useSSL = true,
+        numeric timeout = 0
     ) {
         if ( awsCredentials.isEmpty() ) {
             awsCredentials = credentials.getCredentials();
@@ -86,6 +87,7 @@ component accessors="true" {
         httpArgs[ 'queryParams' ] = queryParams;
         httpArgs[ 'useSSL' ] = useSSL;
         if ( !isNull( arguments.body ) ) httpArgs[ 'body' ] = body;
+        if ( timeout ) httpArgs[ 'timeout' ] = timeout;
         // writeDump( httpArgs );
 
         var requestStart = getTickCount();

--- a/services/s3.cfc
+++ b/services/s3.cfc
@@ -615,7 +615,8 @@ component {
         string Expires = '',
         struct Metadata = { },
         string StorageClass = '',
-        string WebsiteRedirectLocation = ''
+        string WebsiteRedirectLocation = '',
+        numeric timeout = 0
     ) {
         var requestSettings = api.resolveRequestSettings( argumentCollection = arguments );
         var headers = { };
@@ -648,7 +649,8 @@ component {
             '/' & ObjectKey,
             { },
             headers,
-            FileContent
+            FileContent,
+            timeout
         );
         return apiResponse;
     }
@@ -903,7 +905,8 @@ component {
         string path = '/',
         struct queryParams = { },
         struct headers = { },
-        any payload = ''
+        any payload = '',
+        numeric timeout = 0
     ) {
         var host = getHost( requestSettings );
 
@@ -935,7 +938,8 @@ component {
             payload,
             requestSettings.awsCredentials,
             false,
-            useSSL
+            useSSL,
+            timeout
         );
     }
 


### PR DESCRIPTION
When using s3, the default timeout is 50 seconds and I find myself timing out when putting large files. I updated api.cfc and s3.cfc to pass through an optional timeout. If the timeout is 0 (which those files default it to), it will use default value in makeHttpRequest().