### PR TITLE
Add ability to pass through host to SSM

### DIFF
--- a/com/api.cfc
+++ b/com/api.cfc
@@ -35,7 +35,8 @@ component accessors="true" {
     public struct function resolveRequestSettings(
         struct awsCredentials = { },
         string region = defaultRegion,
-        string bucket = ''
+        string bucket = '',
+        string host = ''
     ) {
         if ( !awsCredentials.isEmpty() ) {
             awsCredentials = credentials.defaultCredentials( argumentCollection = awsCredentials );
@@ -43,6 +44,9 @@ component accessors="true" {
         var settings = { awsCredentials: awsCredentials, region: region };
         if ( len( arguments.bucket ) ) {
             settings.bucket = arguments.bucket;
+        }
+        if( len( arguments.host )){
+            settings.host = arguments.host;
         }
         return settings;
     }

--- a/services/ssm.cfc
+++ b/services/ssm.cfc
@@ -8,6 +8,7 @@ component {
     ) {
         variables.api = arguments.api;
         variables.apiVersion = arguments.settings.apiVersion;
+        variables.settings = arguments.settings;
         return this;
     }
 
@@ -50,7 +51,12 @@ component {
     public string function getHost(
         required string region
     ) {
-        return variables.service & '.' & region & '.amazonaws.com';
+        if ( structKeyExists( variables.settings, 'host' ) && len( variables.settings.host ) ) {
+            var host = variables.settings.host;
+        } else {
+            var host = variables.service & '.' & region & '.amazonaws.com';
+        }
+        return host;
     }
 
     private any function apiCall(
@@ -74,9 +80,15 @@ component {
             { },
             headers,
             payloadString,
-            requestSettings.awsCredentials
+            requestSettings.awsCredentials,
+            true
         );
-        apiResponse[ 'data' ] = deserializeJSON( apiResponse.rawData );
+        if (isJson(apiResponse.rawData)){
+            apiResponse[ 'data' ] = deserializeJSON( apiResponse.rawData );
+        }else{
+            apiResponse[ 'data' ] = apiResponse.rawData;
+        }
+        
 
         return apiResponse;
     }


### PR DESCRIPTION
This allows passing through a custom host through to ssm to allow testing with localstack and similar.

This matches how the S3.cfc works.

This also fixes an issue when the SSM service doesn't return json back from the API